### PR TITLE
Fix crash when randomizing trainers on Remix/Expert mode

### DIFF
--- a/025-Randomizer/randomizer gym leader edit.rb
+++ b/025-Randomizer/randomizer gym leader edit.rb
@@ -330,7 +330,7 @@ def Kernel.pbShuffleTrainers(bst_range = 50, customsOnly = false, customsList = 
     customsOnly = false
   end
   randomTrainersHash = Hash.new
-  trainers_data = GameData::Trainer.list_all
+  trainers_data = getTrainersDataMode.list_all
   trainers_data.each do |key, value|
     trainer = trainers_data[key]
     i = 0

--- a/025-Randomizer/randomizer gym leader edit.rb
+++ b/025-Randomizer/randomizer gym leader edit.rb
@@ -330,7 +330,9 @@ def Kernel.pbShuffleTrainers(bst_range = 50, customsOnly = false, customsList = 
     customsOnly = false
   end
   randomTrainersHash = Hash.new
-  trainers_data = getTrainersDataMode.list_all
+  mode = getTrainersDataMode
+  trainers_data = mode.list_all
+  trainers_data = ::GameData::Trainer.list_all.merge(trainers_data) if mode != ::GameData::Trainer # Ensure all classic mode trainers exist
   trainers_data.each do |key, value|
     trainer = trainers_data[key]
     i = 0


### PR DESCRIPTION
A common issue players encounter is when using the update man Pokémon Centers to enable randomisation while playing on Remix or Expert modes, certain trainers will cause the game to crash. The randomizer may not be intended to be used on these game modes so an alternative solution is to disable the option to enable randomization when playing on those modes, however this pull request aims to improve compatibility with those modes and fix the crash instead.

The crash is caused because the randomizer always uses the Classic mode teams when shuffling the trainers but when battling the trainers it will check against the party size of the current mode. So if a trainer only has 2 pokemon in Classic but 3 in Remix, then when the game tries to find the third randomized pokemon, it finds nothing and crashes. This pull request resolves this by using the current game mode's teams and filling in with the classic teams where they don't exist in the current game mode.