### PR TITLE
Fix Lure Ball error on static encounters

### DIFF
--- a/011_Battle/005_BallHandlers_PokeBallEffects.rb
+++ b/011_Battle/005_BallHandlers_PokeBallEffects.rb
@@ -177,7 +177,8 @@ BallHandlers::ModifyCatchRate.add(:LEVELBALL,proc { |ball,catchRate,battle,battl
 
 BallHandlers::ModifyCatchRate.add(:LUREBALL,proc { |ball,catchRate,battle,battler,ultraBeast|
   multiplier = (Settings::NEW_POKE_BALL_CATCH_RATES) ? 5 : 3
-  catchRate *= multiplier if GameData::EncounterType.get($PokemonTemp.encounterType).type == :fishing
+  encounterType = GameData::EncounterType.try_get($PokemonTemp.encounterType)
+  catchRate *= multiplier if encounterType.is_a?(GameData::EncounterType) && encounterType.type == :fishing
   next [catchRate,255].min
 })
 


### PR DESCRIPTION
When using a Lure Ball, the game checks a temporary property for the encounter type. This property is set when the species is selected from the encounter tables. For any encounters started by an event, such as static encounters, this property is not set because the species is predefined and not selected randomly from the encounter tables, so when a Lure Ball is used it causes an error due to the property being undefined.

This pull request adds a check for whether the encounter type is defined and set to a valid type, allowing the item to be used as normal.

Resolves bug reports:
- [Threw a Lure Ball at Moltres](https://discord.com/channels/302153478556352513/1153456841704083527)
- [Lure Ball Weirdness in encounter](https://discord.com/channels/302153478556352513/1176393857848590457)