### PR TITLE
Fix Luvdisc not being randomized by global setting

### DIFF
--- a/025-Randomizer/randomizer.rb
+++ b/025-Randomizer/randomizer.rb
@@ -31,7 +31,7 @@ def get_pokemon_list(include_fusions = false)
   #Create array of all pokemon dex numbers
   pokeArray = []
 
-  monLimit = include_fusions ? PBSpecies.maxValue : NB_POKEMON - 1
+  monLimit = include_fusions ? PBSpecies.maxValue : NB_POKEMON
   for i in 1..monLimit
     pokeArray.push(i)
   end


### PR DESCRIPTION
When the randomizer generates the Global Pokémon mapping, it should loop over every Pokémon to select a new species for each, however the loop currently only goes up to one less than the final (`NB_POKEMON - 1`) and so will never randomize that last pokemon.

Static and gift Pokémon will always use the global mapping regardless of whether Global or Area is selected; and the current last Pokémon "Luvdisc" is given as a gift in Viridian Pokémart making the lack of randomization noticeable.

Resolves bug report:
- [Luvdisc Gift Pokemon not radomizing in 6.4](https://discord.com/channels/302153478556352513/1320220179963056128)