### PR TITLE
Fix ability to surpass level cap from battle exp and unfusing pokemon.

### DIFF
--- a/011_Battle/003_Battle/004_Battle_ExpAndMoveLearning.rb
+++ b/011_Battle/003_Battle/004_Battle_ExpAndMoveLearning.rb
@@ -153,11 +153,27 @@ class PokeBattle_Battle
       i = BattleHandlers.triggerExpGainModifierItem(@initialItems[0][idxParty], pkmn, exp)
     end
     exp = i if i >= 0
+
     # Make sure Exp doesn't exceed the maximum
-
     exp = 0 if $PokemonSystem.level_caps==1 && pokemonExceedsLevelCap(pkmn)
-
     expFinal = growth_rate.add_exp(pkmn.exp, exp)
+
+    # If levelCap is not a whole number, round up since Gym Leader Ace levels do this
+    # I.e if the level cap is 13.2, the Gym Leader's Ace is 14. So the player's level cap is also 14
+    levelCap = getCurrentLevelCap().to_f.ceil
+    
+    # Recalculate exp if pokemon will go above the cap
+    if (growth_rate.level_from_exp(expFinal) > levelCap && $PokemonSystem.level_caps==1 && exp > 0)
+      # Get minimum exp to meet the level cap
+      minExpForLevel = growth_rate.minimum_exp_for_level(levelCap)
+      
+      # Handle edgecase where minExpForLevel is negative
+      minExpForLevel = 0 if minExpForLevel < 0
+
+      # Overwrite expFinal
+      expFinal = minExpForLevel
+    end
+
     expGained = expFinal - pkmn.exp
 
 

--- a/052_InfiniteFusion/New Items effects.rb
+++ b/052_InfiniteFusion/New Items effects.rb
@@ -1651,21 +1651,30 @@ def pbUnfuse(pokemon, scene, supersplicers, pcPosition = nil)
       scene.pbDisplay(_INTL(" ... "))
       scene.pbDisplay(_INTL(" ... "))
 
+      # If levelCap is not a whole number, round up since Gym Leader Ace levels do this
+      # I.e if the level cap is 13.2, the Gym Leader's Ace is 14. So the player's level cap is also 14
+      levelCap = getCurrentLevelCap().to_f.ceil
+
       if pokemon.exp_when_fused_head == nil || pokemon.exp_when_fused_body == nil
         new_level = calculateUnfuseLevelOldMethod(pokemon, supersplicers)
-        body_level = new_level
-        head_level = new_level
-        poke1 = Pokemon.new(bodyPoke, body_level)
-        poke2 = Pokemon.new(headPoke, head_level)
+        new_level = levelCap if ($PokemonSystem.level_caps==1 && new_level > levelCap)
       else
+        new_level = pokemon.level
         exp_body = pokemon.exp_when_fused_body + pokemon.exp_gained_since_fused
         exp_head = pokemon.exp_when_fused_head + pokemon.exp_gained_since_fused
 
-        poke1 = Pokemon.new(bodyPoke, pokemon.level)
-        poke2 = Pokemon.new(headPoke, pokemon.level)
+        # Recalculate level and exp if pokemon would be over the level cap
+        if ($PokemonSystem.level_caps==1)
+          new_level = levelCap if new_level > levelCap
+          exp_body = poke1.growth_rate.minimum_exp_for_level(levelCap) if poke1.growth_rate.minimum_exp_for_level(levelCap) < exp_body
+          exp_head = poke2.growth_rate.minimum_exp_for_level(levelCap) if poke2.growth_rate.minimum_exp_for_level(levelCap) < exp_head
+        end
+        
         poke1.exp = exp_body
         poke2.exp = exp_head
       end
+      poke1 = Pokemon.new(bodyPoke, new_level)
+      poke2 = Pokemon.new(headPoke, new_level)
       body_level = poke1.level
       head_level = poke2.level
 


### PR DESCRIPTION
1. Level Cap Can be Surpassed via Battle Experience (011_Battle/003_Battle/004_Battle_ExpAndMoveLearning.rb ->> pbGainExpOne)
a. It's possible to exceed a level cap if a pokemon who is under the cap gains enough experience at once to level over the cap. 
b. Solution: Before awarding EXP, check the resulting level via growth_rate.level_from_exp. If it exceeds the cap, assign the minimum EXP needed to reach (but not exceed) the level cap instead.
c. (Alternatively, we could assign the maximum EXP for the capped level — let me know if that’s preferred.)

2. Level Cap Can be Surpassed via Un-fusion (052_InfiniteFusion/New Items effects.rb ->> pbUnfuse)
a. When unfusing a fusion, one or both resulting Pokémon can end up over the level cap.
b. Solution: During unfusion, check the level using growth_rate.level_from_exp. If the level exceeds the cap, set EXP to the minimum for the capped level.
c. This approach can lead to a situation where: Fusing two level-cap Pokémon, then unfusing them, results in pokemon that are below the level cap depending on their individual growth rates.
c. This fix does NOT address the related issue where fusing two capped pokemon can result in a fusion that exceeds the cap.
