### PR TITLE
Translation related fix

### DIFF
--- a/001_Technical/003_Intl_Messages.rb
+++ b/001_Technical/003_Intl_Messages.rb
@@ -1,6 +1,6 @@
 def pbAddScriptTexts(items, script)
   script.force_encoding(Encoding::UTF_8)
-  script.scan(/(?:_I)\s*\(\s*\"((?:[^\\\"]*\\\"?)*[^\"]*)\"/) do |s|
+  script.scan(/(?:_I|sign)\s*\(\s*\"((?:[^\\\"]*\\\"?)*[^\"]*)\"/) do |s|
     string = s[0]
     string.gsub!(/\\\"/, "\"")
     string.gsub!(/\\\\/, "\\")

--- a/001_Technical/003_Intl_Messages.rb
+++ b/001_Technical/003_Intl_Messages.rb
@@ -35,17 +35,13 @@ def pbSetTextMessages
       scr = Zlib::Inflate.inflate(script[2])
       pbAddRgssScriptTexts(texts, scr)
     end
-    # If Scripts.rxdata only has 1 section, scripts have been extracted. Get
-    # script texts from .rb files in Data/Scripts
-    if $RGSS_SCRIPTS.length == 1
-      Dir.all("Data/Scripts").each do |script_file|
-        if System.uptime - t >= 5
-          t += 5
-          Graphics.update
-        end
-        File.open(script_file, "rb") do |f|
-          pbAddRgssScriptTexts(texts, f.read)
-        end
+    Dir.all("Data/Scripts").each do |script_file|
+      if System.uptime - t >= 5
+        t += 5
+        Graphics.update
+      end
+      File.open(script_file, "rb") do |f|
+        pbAddRgssScriptTexts(texts, f.read)
       end
     end
     # Must add messages because this code is used by both game system and Editor

--- a/007_Objects and windows/010_DrawText.rb
+++ b/007_Objects and windows/010_DrawText.rb
@@ -244,6 +244,20 @@ def getFormattedTextFast(bitmap,xDst,yDst,widthDst,heightDst,text,lineheight,
         x+=charwidth
       end
       lastword[1]=0
+    elsif !explicitBreaksOnly && x+2>widthDst && lastword[1]==0 &&
+          characters.length > 0 && characters[-1][0] != "\n"
+      havenl=true
+      break_index = characters.length - 1
+      characters.insert(break_index,["\n",0,y*lineheight+yDst,0,lineheight,
+         false,false,false,colorclone,nil,false,false,"",8,position])
+      y+=1
+      x=0
+      for i in break_index+1...characters.length
+        characters[i][2]+=lineheight
+        charwidth=characters[i][3]-2
+        characters[i][1]=x
+        x+=charwidth
+      end
     end
     position+=1
   end
@@ -741,6 +755,24 @@ def getFormattedText(bitmap,xDst,yDst,widthDst,heightDst,text,lineheight=32,
         x+=charwidth
       end
       lastword[1]=0
+    elsif !explicitBreaksOnly && x+2>widthDst && lastword[1]==0 &&
+          characters.length > 0 && characters[-1][0] != "\n"
+      havenl=true
+      break_index = characters.length - 1
+      characters.insert(break_index,["\n",0,y*lineheight+yDst,0,lineheight,false,
+         false,false,defaultcolors[0],defaultcolors[1],false,false,"",8,position,
+         nil])
+      charactersInternal.insert(break_index,[alignment,y,0])
+      y+=1
+      x=0
+      for i in break_index+1...characters.length
+        characters[i][2]+=lineheight
+        charactersInternal[i][1]+=1
+        extraspace=(charactersInternal[i][4]) ? charactersInternal[i][4] : 0
+        charwidth=characters[i][3]-extraspace
+        characters[i][1]=x+charactersInternal[i][2]
+        x+=charwidth
+      end
     end
     position+=1 if !graphic
   end
@@ -984,6 +1016,19 @@ def getLineBrokenChunks(bitmap,value,width,dims,plain=false)
             x=0
             y+=32
           end
+        end
+        if textwidth>width && word.scan(/\s/).empty?
+          word.scan(/./m).each do |char|
+            charwidth=bitmap.text_size(char).width
+            if x>0 && x+charwidth>width
+              x=0
+              y+=32
+            end
+            ret.push([char,x,y,charwidth,32,color])
+            x+=charwidth
+            dims[0]=x if dims && dims[0]<x
+          end
+          next
         end
         ret.push([word,x,y,textwidth,32,color])
         x+=textwidth

--- a/010_Data/002_PBS data/008_Species.rb
+++ b/010_Data/002_PBS data/008_Species.rb
@@ -192,26 +192,23 @@ module GameData
     end
     # @return [String] the translated name of this species
     def name
-      return @real_name
-      #return pbGetMessage(MessageTypes::Species, @id_number)
+      ret = MessageTypes.get(MessageTypes::Species, @id_number)
+      return (ret && !ret.empty?) ? ret : @real_name
     end
 
-    # @return [String] the translated name of this form of this species
     def form_name
-      return @real_form_name
-      #return pbGetMessage(MessageTypes::FormNames, @id_number)
+      ret = MessageTypes.get(MessageTypes::FormNames, @id_number)
+      return (ret && !ret.empty?) ? ret : @real_form_name
     end
 
-    # @return [String] the translated Pokédex category of this species
     def category
-      return @real_category
-      #return pbGetMessage(MessageTypes::Kinds, @id_number)
+      ret = MessageTypes.get(MessageTypes::Kinds, @id_number)
+      return (ret && !ret.empty?) ? ret : @real_category
     end
 
-    # @return [String] the translated Pokédex entry of this species
     def pokedex_entry
-      return @real_pokedex_entry
-      #return pbGetMessage(MessageTypes::Entries, @id_number)
+      ret = MessageTypes.get(MessageTypes::Entries, @id_number)
+      return (ret && !ret.empty?) ? ret : @real_pokedex_entry
     end
 
     def is_fusion

--- a/016_UI/001_UI_PauseMenu.rb
+++ b/016_UI/001_UI_PauseMenu.rb
@@ -128,13 +128,13 @@ class PokemonPauseMenu
     cmdQuit = -1
     cmdEndGame = -1
     if $Trainer.has_pokedex && $Trainer.pokedex.accessible_dexes.length > 0
-      commands[cmdPokedex = commands.length] = _INTL("  <icon=#{ICON_POKEDEX}>  Pokédex")
+      commands[cmdPokedex = commands.length] = "  <icon=#{ICON_POKEDEX}>  " + _INTL("Pokédex")
     end
-    commands[cmdPokemon = commands.length] = _INTL("  <icon=#{ICON_POKEMON}>  Pokémon") if $Trainer.party_count > 0
-    commands[cmdBag = commands.length] = _INTL("  <icon=#{ICON_BAG}>  Bag") if !pbInBugContest?
-    commands[cmdPokegear = commands.length] = _INTL("  <icon=#{ICON_POKENAV}>  PokéNav") if $Trainer.has_pokegear
-    commands[cmdTrainer = commands.length] = _INTL("  <icon=#{ICON_PLAYER}>  {1}",$Trainer.name)
-    commands[cmdOutfit = commands.length] = _INTL("  <icon=#{ICON_OUTFIT}>  Outfit") if $Trainer.can_change_outfit
+    commands[cmdPokemon = commands.length] = "  <icon=#{ICON_POKEMON}>  " + _INTL("Pokémon") if $Trainer.party_count > 0
+    commands[cmdBag = commands.length] = "  <icon=#{ICON_BAG}>  " + _INTL("Bag") if !pbInBugContest?
+    commands[cmdPokegear = commands.length] = "  <icon=#{ICON_POKENAV}>  " + _INTL("PokéNav") if $Trainer.has_pokegear
+    commands[cmdTrainer = commands.length] = "  <icon=#{ICON_PLAYER}>  " + _INTL("{1}", $Trainer.name)
+    commands[cmdOutfit = commands.length] = "  <icon=#{ICON_OUTFIT}>  " + _INTL("Outfit") if $Trainer.can_change_outfit
     if pbInSafari?
       if Settings::SAFARI_STEPS <= 0
         @scene.pbShowInfo(_INTL("Balls: {1}", pbSafariState.ballcount))
@@ -142,7 +142,7 @@ class PokemonPauseMenu
         @scene.pbShowInfo(_INTL("Steps: {1}/{2}\nBalls: {3}",
                                 pbSafariState.steps, Settings::SAFARI_STEPS, pbSafariState.ballcount))
       end
-      commands[cmdQuit = commands.length] = _INTL("  <icon=#{ICON_QUIT_SAFARI}>  Quit")
+      commands[cmdQuit = commands.length] = "  <icon=#{ICON_QUIT_SAFARI}>  " + _INTL("Quit")
     elsif pbInBugContest?
       if pbBugContestState.lastPokemon
         @scene.pbShowInfo(_INTL("Caught: {1}\nLevel: {2}\nBalls: {3}",
@@ -154,11 +154,11 @@ class PokemonPauseMenu
       end
       commands[cmdQuit = commands.length] = _INTL("Quit Contest")
     else
-      commands[cmdSave = commands.length] = _INTL("  <icon=#{ICON_SAVE}>  Save") if $game_system && !$game_system.save_disabled
+      commands[cmdSave = commands.length] = "  <icon=#{ICON_SAVE}>  " + _INTL("Save") if $game_system && !$game_system.save_disabled
     end
-    commands[cmdOption = commands.length] = _INTL("  <icon=#{ICON_OPTIONS}>  Options")
-    commands[cmdDebug = commands.length] = _INTL("  <icon=#{ICON_DEBUG}>  Debug") if $DEBUG
-    commands[cmdEndGame = commands.length] = _INTL("  <icon=#{ICON_TITLE}>  Title")
+    commands[cmdOption = commands.length] = "  <icon=#{ICON_OPTIONS}>  " + _INTL("Options")
+    commands[cmdDebug = commands.length] = "  <icon=#{ICON_DEBUG}>  " + _INTL("Debug") if $DEBUG
+    commands[cmdEndGame = commands.length] = "  <icon=#{ICON_TITLE}>  " + _INTL("Title")
     loop do
       command = @scene.pbShowCommands(commands)
       if cmdPokedex >= 0 && command == cmdPokedex

--- a/016_UI/Pokedex/003_UI_Pokedex_Main.rb
+++ b/016_UI/Pokedex/003_UI_Pokedex_Main.rb
@@ -369,7 +369,7 @@ class PokemonPokedex_Scene
       if $Trainer.seen?(nationalSpecies)
         if !filter_owned || $Trainer.owned?(nationalSpecies)
           species = GameData::Species.get(nationalSpecies)
-          dexlist.push([species.id_number, species.real_name, 0, 0, i + 1, 0])
+          dexlist.push([species.id_number, species.name, 0, 0, i + 1, 0])
         end
       end
     end

--- a/052_InfiniteFusion/Gameplay/Overworld/Events/OverworldEventUtils.rb
+++ b/052_InfiniteFusion/Gameplay/Overworld/Events/OverworldEventUtils.rb
@@ -69,7 +69,8 @@ end
 # 1: wood
 def sign(message, type = 0)
   signId = "sign_#{type}"
-  formatted_message = "\\sign[#{signId}]#{message}"
+  translated = MessageTypes.getFromMapHash($game_map.map_id, message)
+  formatted_message = "\\sign[#{signId}]#{translated}"
   pbMessage(formatted_message)
 end
 

--- a/052_InfiniteFusion/System/Game Options/GameOptions.rb
+++ b/052_InfiniteFusion/System/Game Options/GameOptions.rb
@@ -15,7 +15,7 @@ class PokemonGameOption_Scene < PokemonOption_Scene
         @system_menu = true
         openSystemMenu()
       },
-      _INTL("<icon=#{ICON_AUDIO}> Volume, UI, Autosave, etc.")
+      "<icon=#{ICON_AUDIO}> " + _INTL("Volume, UI, Autosave, etc.")
     )
 
     if $game_switches
@@ -25,7 +25,7 @@ class PokemonGameOption_Scene < PokemonOption_Scene
           @gameplay_menu = true
           openGameplayMenu()
         },
-        _INTL("<icon=#{ICON_GAMEPLAY}> Difficulty, movement, etc.")
+        "<icon=#{ICON_GAMEPLAY}> " + _INTL("Difficulty, movement, etc.")
       )
 
       options << ButtonOption.new(
@@ -34,7 +34,7 @@ class PokemonGameOption_Scene < PokemonOption_Scene
           @sprites_menu = true
           openSpritesMenu()
         },
-        _INTL("<icon=#{ICON_VISUALS}> Sprites, Pokédex entries, etc.")
+        "<icon=#{ICON_VISUALS}> " + _INTL("Sprites, Pokédex entries, etc.")
       )
 
       options << ButtonOption.new(
@@ -43,7 +43,7 @@ class PokemonGameOption_Scene < PokemonOption_Scene
           @challenge_menu = true
           openChallengeMenu()
         },
-        _INTL("<icon=#{ICON_CHALLENGE}> Set optional self-imposed challenges.")
+        "<icon=#{ICON_CHALLENGE}> " + _INTL("Set optional self-imposed challenges.")
       )
 
       # if $game_switches[SWITCH_RANDOMIZED_AT_LEAST_ONCE]
@@ -53,7 +53,7 @@ class PokemonGameOption_Scene < PokemonOption_Scene
       #       @randomizer_menu = true
       #       openRandomizerMenu()
       #     },
-      #     _INTL("<icon=#{ICON_RANDOMIZER}> Set how to randomize the game.")
+      #     "<icon=#{ICON_RANDOMIZER}> " + _INTL("Set how to randomize the game.")
       #   )
       # end
     end


### PR DESCRIPTION
Hope I didn't bother you too much.

1. [001_UI_PauseMenu.rb] & [GameOptions.rb]

    Separate icons from text to prevent <icon=#{ICON_xxx}> from being extracted into intl.
    This ensures that the menus in the translated version display the translated content correctly.
    the intl output before:
    <img width="243" height="153" alt="image" src="https://github.com/user-attachments/assets/5d1e41ec-c2cd-47b4-afd2-8a0dbc81ba3c" />
    the intl output after:
    <img width="326" height="374" alt="image" src="https://github.com/user-attachments/assets/8b748b1b-867b-433d-8cdb-0e505f55e005" />
    <img width="297" height="398" alt="image" src="https://github.com/user-attachments/assets/5bcd1317-e6b4-4b8a-8c56-ed2b88fe7cac" />

 ——————————————————————————————————————————————

2. [010_DrawText.rb] 
    Add a line break function for the Chinese translation version.
    **This is vital for Chinese translation version.**
    <img width="1026" height="814" alt="image" src="https://github.com/user-attachments/assets/b222f2d2-4ebd-49f2-a852-241991570ec1" />
    <img width="1026" height="814" alt="image" src="https://github.com/user-attachments/assets/1d85dc96-e572-4be3-a842-e306f1e58040" />

 ——————————————————————————————————————————————

4. [003_Intl_Messages.rb]

    Fix: the INTL texts under Scripts Folder were not being successfully extracted when extracting the intl file.  
    Similar to https://github.com/infinitefusion/scripts/pull/15

 ——————————————————————————————————————————————
 

5. [008_Species.rb] & [003_UI_Pokedex_Main.rb]

    Fix: Pokémon names and other texts in the translated version were not being displayed correctly.
    Fix: Pokémon name not displaying in Pokédex for individual entries.
    Similar to https://github.com/infinitefusion/scripts/pull/13/
    <img width="1019" height="453" alt="5404642783d928be0bfacfc625cf2593" src="https://github.com/user-attachments/assets/ef045df7-72bd-4d86-985b-a0b4e963c847" />

  ——————————————————————————————————————————————
 

6. [OverworldEventUtils.rb] & [003_Intl_Messages.rb]

    Fix the issue that "sign" txt wasn't extracted. 
    Fix display of sign translation
    
    Change it to sign(_I("\PN's house"),1) works too. @ITGourmand mentioned that there are a few cases in PIF1 like this and it's reported here https://discord.com/channels/1327311426704117944/1355200935638335640
    So,change directly from the map script would be a long-term choice, while the solution in this PR can be a temporary workaround (given that similar issues are present in both PIF1 and PIF2).
    <img width="286" height="106" alt="d4f7061ebc89785d7d7d14be4b6dbfe8" src="https://github.com/user-attachments/assets/30104bc0-f7ed-4ee8-9b4e-15894038de5b" />
    <img width="1026" height="814" alt="23f8b6497b429961a59acb37b75d6ac5" src="https://github.com/user-attachments/assets/d292fa09-e50f-4b7d-a9bd-07022cc34d9c" />


