### PR TITLE
Translation fix2

### DIFF
--- a/001_Technical/001_Debugging/005_Deprecation.rb
+++ b/001_Technical/001_Debugging/005_Deprecation.rb
@@ -8,7 +8,7 @@ module Deprecation
   # @param removal_version [String] version the method is removed in
   # @param alternative [String] preferred alternative method
   def warn_method(method_name, removal_version = nil, alternative = nil)
-    text = _INTL('WARN: usage of deprecated method "{1}" or its alias.', method_name)
+    text = _INTL("WARN: usage of deprecated method '{1}' or its alias.", method_name)
     unless removal_version.nil?
       text += _INTL("\nThe method is slated to be"\
                     " removed in Essentials {1}.", removal_version)

--- a/003_Game processing/001_StartGame.rb
+++ b/003_Game processing/001_StartGame.rb
@@ -17,7 +17,7 @@ module Game
     GameData.load_all
     map_file = format('Data/Map%03d.rxdata', $data_system.start_map_id)
     if $data_system.start_map_id == 0 || !pbRgssExists?(map_file)
-      raise _INTL('No starting position was set in the map editor.')
+      raise _INTL("No starting position was set in the map editor.")
     end
   end
 
@@ -217,13 +217,13 @@ module Game
         $MapFactory.setup($game_map.map_id)
       rescue Errno::ENOENT
         if $DEBUG
-          pbMessage(_INTL('Map {1} was not found.', $game_map.map_id))
+          pbMessage(_INTL("Map {1} was not found.", $game_map.map_id))
           map = pbWarpToMapList
           exit unless map
           $MapFactory.setup(map[0])
           $game_player.moveto(map[1], map[2])
         else
-          raise _INTL('The map was not found. The game cannot continue.')
+          raise _INTL("The map was not found. The game cannot continue.")
         end
       end
       $game_player.center($game_player.x, $game_player.y)
@@ -231,7 +231,7 @@ module Game
       $MapFactory.setMapChanged($game_map.map_id)
     end
     if $game_map.events.nil?
-      raise _INTL('The map is corrupt. The game cannot continue.')
+      raise _INTL("The map is corrupt. The game cannot continue.")
     end
     $PokemonEncounters = PokemonEncounters.new
     $PokemonEncounters.setup($game_map.map_id)

--- a/007_Objects and windows/011_Messages.rb
+++ b/007_Objects and windows/011_Messages.rb
@@ -341,7 +341,10 @@ def pbGetBasicMapNameFromId(id)
 end
 
 def pbGetMapNameFromId(id)
-  map = pbGetBasicMapNameFromId(id)
+  map = pbGetMessage(MessageTypes::MapNames, id)
+  if nil_or_empty?(map)
+    map = pbGetBasicMapNameFromId(id)
+  end
   map.gsub!(/\\PN/, $Trainer.name) if $Trainer
   return map
 end

--- a/011_Battle/003_Battle/002_PokeBattle_Battle.rb
+++ b/011_Battle/003_Battle/002_PokeBattle_Battle.rb
@@ -708,12 +708,12 @@ class PokeBattle_Battle
     when :HarshSun
       if !pbCheckGlobalAbility(:DESOLATELAND)
         @field.weather = :None
-        pbDisplay("The harsh sunlight faded!")
+        pbDisplay(_INTL("The harsh sunlight faded!"))
       end
     when :HeavyRain
       if !pbCheckGlobalAbility(:PRIMORDIALSEA)
         @field.weather = :None
-        pbDisplay("The heavy rain has lifted!")
+        pbDisplay(_INTL("The heavy rain has lifted!"))
       end
     # when :StrongWinds
     #   if !pbCheckGlobalAbility(:DELTASTREAM)

--- a/011_Battle/006_Other battle types/009_PokeBattle_Clauses.rb
+++ b/011_Battle/006_Other battle types/009_PokeBattle_Clauses.rb
@@ -194,7 +194,7 @@ class PokeBattle_Move_0E0   # Self-Destruct
       count  = @battle.pbAbleNonActiveCount(user.idxOwnSide)
       count += @battle.pbAbleNonActiveCount(user.idxOpposingSide)
       if count==0
-        @battle.pbDisplay("But it failed!")
+        @battle.pbDisplay(_INTL("But it failed!"))
         return false
       end
     end

--- a/014_Pokemon/001_Pokemon.rb
+++ b/014_Pokemon/001_Pokemon.rb
@@ -549,7 +549,7 @@ class Pokemon
     return if !able?
     new_status = GameData::Status.try_get(value)
     if !new_status
-      raise ArgumentError, _INTL('Attempted to set {1} as Pokémon status', value.class.name)
+      raise ArgumentError, _INTL("Attempted to set {1} as Pokémon status", value.class.name)
     end
     @status = new_status.id
   end
@@ -923,7 +923,7 @@ class Pokemon
   # @param mail [Mail, nil] mail to be held by this Pokémon
   def mail=(mail)
     if !mail.nil? && !mail.is_a?(Mail)
-      raise ArgumentError, _INTL('Invalid value {1} given', mail.inspect)
+      raise ArgumentError, _INTL("Invalid value {1} given", mail.inspect)
     end
     @mail = mail
   end
@@ -1345,7 +1345,7 @@ class Pokemon
       _INTL("Evolve body!"),
       _INTL("Don't evolve")
     ]
-    choice = pbMessage(_INTL('\\f[{2}]Both halves of {1} are ready to evolve!', self.name,self.id_number), choices, 0)
+    choice = pbMessage(_INTL("\\f[{2}]Both halves of {1} are ready to evolve!", self.name,self.id_number), choices, 0)
     # if choice == 0  #EVOLVE BOTH
     #   newspecies = getFusionSpecies(body_evolution,head_evolution)
     if choice == 0 #EVOLVE HEAD

--- a/016_UI/001_Non-interactive UI/006_UI_HallOfFame.rb
+++ b/016_UI/001_Non-interactive UI/006_UI_HallOfFame.rb
@@ -430,32 +430,32 @@ class HallOfFame_Scene
 
 
   def getCurrentGameMode()
-    gameMode = "Classic mode"
+    gameMode = _INTL("Classic mode")
     if $game_switches[SWITCH_MODERN_MODE]
-      gameMode = "Remix mode"
+      gameMode = _INTL("Remix mode")
     end
     if $game_switches[SWITCH_EXPERT_MODE]
-      gameMode = "Expert mode"
+      gameMode = _INTL("Expert mode")
     end
     if $game_switches[SWITCH_SINGLE_POKEMON_MODE]
       pokemon_number = pbGet(VAR_SINGLE_POKEMON_MODE)
       if pokemon_number.is_a?(Integer) && pokemon_number > 0
         pokemon = GameData::Species.get(pokemon_number)
-        gameMode = pokemon.real_name + " mode"
+        gameMode = _INTL("{1} mode",pokemon.real_name)
       else
-        gameMode = "Debug mode"
+        gameMode = _INTL("Debug mode")
       end
     end
     if $game_switches[SWITCH_RANDOMIZED_AT_LEAST_ONCE]
-      gameMode = "Randomized mode"
+      gameMode = _INTL("Randomized mode")
     end
 
     if $game_switches[SWITCH_LEGENDARY_MODE]
-      gameMode = "Legendary mode"
+      gameMode = _INTL("Legendary mode")
     end
 
     if $game_switches[ENABLED_DEBUG_MODE_AT_LEAST_ONCE] || $DEBUG
-      gameMode = "Debug mode"
+      gameMode = _INTL("Debug mode")
     end
     return gameMode
   end

--- a/016_UI/012_UI_TrainerCard.rb
+++ b/016_UI/012_UI_TrainerCard.rb
@@ -73,7 +73,7 @@ class PokemonTrainerCard_Scene
         end
       end
     else
-      pbMessage("You can purchase new Trainer Card backgrounds at Poké Marts!")
+      pbMessage(_INTL("You can purchase new Trainer Card backgrounds at Poké Marts!"))
     end
   end
 

--- a/016_UI/013_UI_Load.rb
+++ b/016_UI/013_UI_Load.rb
@@ -229,7 +229,7 @@ class PokemonLoadScreen
     save_data = SaveData.read_from_file(file_path)
     unless SaveData.valid?(save_data)
       if File.file?(file_path + '.bak')
-        pbMessage(_INTL('The save file is corrupt. A backup will be loaded.'))
+        pbMessage(_INTL("The save file is corrupt. A backup will be loaded."))
         save_data = load_save_file(file_path + '.bak')
       else
         self.prompt_save_deletion
@@ -242,9 +242,9 @@ class PokemonLoadScreen
   # Called if all save data is invalid.
   # Prompts the player to delete the save files.
   def prompt_save_deletion
-    pbMessage(_INTL('The save file is corrupt, or is incompatible with this game.'))
+    pbMessage(_INTL("The save file is corrupt, or is incompatible with this game."))
     exit unless pbConfirmMessageSerious(
-      _INTL('Do you want to delete the save file and start anew?')
+      _INTL("Do you want to delete the save file and start anew?")
     )
     self.delete_save_data
     $game_system   = Game_System.new
@@ -272,9 +272,9 @@ class PokemonLoadScreen
   def delete_save_data
     begin
       SaveData.delete_file
-      pbMessage(_INTL('The saved data was deleted.'))
+      pbMessage(_INTL("The saved data was deleted."))
     rescue SystemCallError
-      pbMessage(_INTL('All saved data could not be deleted.'))
+      pbMessage(_INTL("All saved data could not be deleted."))
     end
   end
 
@@ -307,19 +307,19 @@ class PokemonLoadScreen
     show_continue = !@save_data.empty?
     new_game_plus = show_continue && (@save_data[:player].new_game_plus_unlocked || $DEBUG)
     if show_continue
-      commands[cmd_continue = commands.length] = _INTL('Continue')
+      commands[cmd_continue = commands.length] = _INTL("Continue")
       if @save_data[:player].mystery_gift_unlocked
-        commands[cmd_mystery_gift = commands.length] = _INTL('Mystery Gift')
+        commands[cmd_mystery_gift = commands.length] = _INTL("Mystery Gift")
       end
     end
-    commands[cmd_new_game = commands.length]  = _INTL('New Game')
+    commands[cmd_new_game = commands.length]  = _INTL("New Game")
     if new_game_plus
-      commands[cmd_new_game_plus = commands.length]  = _INTL('New Game +')
+      commands[cmd_new_game_plus = commands.length]  = _INTL("New Game +")
     end
-    commands[cmd_options = commands.length]   = _INTL('System Options')
-    commands[cmd_language = commands.length]  = _INTL('Language') if Settings::LANGUAGES[Settings::GAME_ID].length >= 2
-    commands[cmd_debug = commands.length]     = _INTL('Debug') if $DEBUG
-    commands[cmd_quit = commands.length]      = _INTL('Quit Game')
+    commands[cmd_options = commands.length]   = _INTL("System Options")
+    commands[cmd_language = commands.length]  = _INTL("Language") if Settings::LANGUAGES[Settings::GAME_ID].length >= 2
+    commands[cmd_debug = commands.length]     = _INTL("Debug") if $DEBUG
+    commands[cmd_quit = commands.length]      = _INTL("Quit Game")
     map_id = show_continue ? @save_data[:map_factory].map.map_id : 0
     @scene.pbStartScene(commands, show_continue, @save_data[:player],
                         @save_data[:frame_count] || 0, map_id)

--- a/016_UI/014_UI_Save.rb
+++ b/016_UI/014_UI_Save.rb
@@ -89,13 +89,13 @@ class PokemonSaveScreen
   def pbSaveScreen
     ret = false
     @scene.pbStartScreen
-    if pbConfirmMessage(_INTL('Would you like to save the game?'))
+    if pbConfirmMessage(_INTL("Would you like to save the game?"))
       if SaveData.exists? && $PokemonTemp.begunNewGame
-        pbMessage(_INTL('WARNING!'))
-        pbMessage(_INTL('There is a different game file that is already saved.'))
+        pbMessage(_INTL("WARNING!"))
+        pbMessage(_INTL("There is a different game file that is already saved."))
         pbMessage(_INTL("If you save now, the other file's adventure, including items and Pokémon, will be entirely lost."))
         if !pbConfirmMessageSerious(
-            _INTL('Are you sure you want to save now and overwrite the other save file?'))
+            _INTL("Are you sure you want to save now and overwrite the other save file?"))
           pbSEPlay('GUI save choice')
           @scene.pbEndScreen
           return false

--- a/016_UI/019_UI_PC.rb
+++ b/016_UI/019_UI_PC.rb
@@ -25,7 +25,7 @@ class StorageSystemPC
   end
 
   def name
-    return "Pokemon Storage"
+    return _INTL("Pokemon Storage");
     #if $Trainer.seen_storage_creator
     #  return "{1}'s PC",pbGetStorageCreator
     #else

--- a/016_UI/020_UI_PokeMart.rb
+++ b/016_UI/020_UI_PokeMart.rb
@@ -252,7 +252,7 @@ end
 #
 #===============================================================================
 class PokemonMart_Scene
-  def initialize(currency_name = "Money")
+  def initialize(currency_name = _INTL("Money"))
     @currency_name = currency_name
   end
 

--- a/016_UI/022_UI_PurifyChamber.rb
+++ b/016_UI/022_UI_PurifyChamber.rb
@@ -503,7 +503,7 @@ class PurifyChamberScreen
             @scene.pbSummary(cmd[1],heldpkmn)
           elsif choice==2
             if pbBoxesFull?
-              @scene.pbDisplay("All boxes are full.")
+              @scene.pbDisplay(_INTL("All boxes are full."))
             elsif heldpkmn
               @scene.pbWithdraw(cmd[1],heldpkmn)
               $PokemonStorage.pbStoreCaught(heldpkmn)
@@ -558,9 +558,9 @@ class PurifyChamberScreen
         heldpkmn=pkmn if pkmn
       else # cancel
         if heldpkmn
-          @scene.pbDisplay("You're holding a Pokémon!")
+          @scene.pbDisplay(_INTL("You're holding a Pokémon!"))
         else
-          if !@scene.pbConfirm("Continue editing sets?")
+          if !@scene.pbConfirm(_INTL("Continue editing sets?"))
             break
           end
         end
@@ -616,7 +616,7 @@ class PurifyChamberScreen
       @chamber.setShadow(set,nil) # Remove shadow Pokemon from set
       if (i+1)!=purifiables.length
         @scene.pbDisplay(_INTL("There is another Pokémon that is ready to open its heart!"))
-        if !@scene.pbConfirm("Would you like to switch sets?")
+        if !@scene.pbConfirm(_INTL("Would you like to switch sets?"))
           @scene.pbCloseSet()
           break
         end
@@ -637,7 +637,7 @@ class PurifyChamberScreen
     loop do
       set=@scene.pbChooseSet
       if set<0
-        if !@scene.pbConfirm("Continue viewing holograms?")
+        if !@scene.pbConfirm(_INTL("Continue viewing holograms?"))
           break
         end
       else

--- a/020_Debug/001_Editor_Utilities.rb
+++ b/020_Debug/001_Editor_Utilities.rb
@@ -126,7 +126,7 @@ def pbChooseSpeciesList(default = nil,max=nil)
   max = max ? max : PBSpecies.maxValue
   params.setRange(1,max)
   params.setInitialValue(defaultNumber)
-  dexNum = pbMessageChooseNumber("dex number?",params)
+  dexNum = pbMessageChooseNumber(_INTL("dex number?"),params)
   return GameData::Species.get(dexNum)
 end
 

--- a/020_Debug/003_Debug menus/003_Debug_MenuExtraCode.rb
+++ b/020_Debug/003_Debug menus/003_Debug_MenuExtraCode.rb
@@ -11,7 +11,7 @@ def pbWarpToMapId
   params = ChooseNumberParams.new
   params.setRange(1,999) #pbMapTree().length)
   params.setDefaultValue($game_map.map_id)
-  map_id = pbMessageChooseNumber("map id?",params)
+  map_id = pbMessageChooseNumber(_INTL("map id?"),params)
   return [map_id,0,0]
 end
 

--- a/020_Debug/003_Debug menus/005_Debug_PokemonCommands.rb
+++ b/020_Debug/003_Debug menus/005_Debug_PokemonCommands.rb
@@ -858,9 +858,9 @@ PokemonDebugMenuCommands.register("speciesform", {
       when 1   # Set form
         old_head_dex = get_head_number_from_symbol(pkmn.species)
         old_body_dex = get_body_number_from_symbol(pkmn.species)
-        pbMessage('Head species?')
+        pbMessage(_INTL("Head species?"))
         head_species = pbChooseSpeciesList(old_head_dex,NB_POKEMON)
-        pbMessage('Body species?')
+        pbMessage(_INTL("Body species?"))
         body_species = pbChooseSpeciesList(old_body_dex,NB_POKEMON)
 
         fused_species_dex = getFusionSpecies(body_species.species, head_species.species)

--- a/025-Randomizer/randomizer gym leader edit.rb
+++ b/025-Randomizer/randomizer gym leader edit.rb
@@ -191,31 +191,31 @@ end
 
 #summarize random options
 def Kernel.sumRandomOptions()
-  answer = $game_switches[SWITCH_RANDOM_STARTERS] ? "On" : "Off"
-  stringOptions = "\nStarters: " << answer
+  answer = $game_switches[SWITCH_RANDOM_STARTERS] ? _INTL("On") : _INTL("Off")
+  stringOptions = _INTL("\nStarters: ") << answer
 
-  answer = $game_switches[SWITCH_RANDOM_WILD] ? "On" : "Off"
-  stringOptions << "\nWild Pokémon: " << answer << " "
+  answer = $game_switches[SWITCH_RANDOM_WILD] ? _INTL("On") : _INTL("Off")
+  stringOptions << _INTL("\nWild Pokémon: ") << answer << " "
   if $game_switches[SWITCH_RANDOM_WILD_AREA]
-    stringOptions << "(Area)"
+    stringOptions << _INTL("(Area)")
   else
-    stringOptions << "(Global)"
+    stringOptions << _INTL("(Global)")
   end
 
-  answer = $game_switches[SWITCH_RANDOM_TRAINERS] ? "On" : "Off"
-  stringOptions << "\nTrainers: " << answer
+  answer = $game_switches[SWITCH_RANDOM_TRAINERS] ? _INTL("On") : _INTL("Off")
+  stringOptions << _INTL("\nTrainers: ") << answer
 
-  answer = $game_switches[SWITCH_RANDOM_STATIC_ENCOUNTERS] ? "On" : "Off"
-  stringOptions << "\nStatic encounters: " << answer
+  answer = $game_switches[SWITCH_RANDOM_STATIC_ENCOUNTERS] ? _INTL("On") : _INTL("Off")
+  stringOptions << _INTL("\nStatic encounters: ") << answer
 
-  answer = $game_switches[SWITCH_RANDOM_GIFT_POKEMON] ? "On" : "Off"
-  stringOptions << "\nGift Pokémon: " << answer
+  answer = $game_switches[SWITCH_RANDOM_GIFT_POKEMON] ? _INTL("On") : _INTL("Off")
+  stringOptions << _INTL("\nGift Pokémon: ") << answer
 
-  answer = $game_switches[SWITCH_RANDOM_ITEMS] ? "On" : "Off"
-  stringOptions << "\nItems: " << answer
+  answer = $game_switches[SWITCH_RANDOM_ITEMS] ? _INTL("On") : _INTL("Off")
+  stringOptions << _INTL("\nItems: ") << answer
 
-  answer = $game_switches[SWITCH_RANDOM_TMS] ? "On" : "Off"
-  stringOptions << "\nTMs: " << answer
+  answer = $game_switches[SWITCH_RANDOM_TMS] ? _INTL("On") : _INTL("Off")
+  stringOptions << _INTL("\nTMs: ") << answer
 
   return stringOptions
 end
@@ -231,40 +231,40 @@ end
 def Kernel.sumGameStats()
   stringStats = ""
 
-  stringStats << "Seen " << $Trainer.pokedexSeen.to_s << " Pokémon"
-  stringStats << "\nCaught " << $Trainer.pokedexOwned.to_s << " Pokémon"
+  stringStats << _INTL("Seen {1} Pokémon",$Trainer.pokedexSeen.to_s)
+  stringStats << _INTL("\nCaught {1} Pokémon",$Trainer.pokedexOwned.to_s)
 
-  stringStats << "\nBeat the Elite Four " << $game_variables[VAR_STAT_NB_ELITE_FOUR].to_s << " times"
-  stringStats << "\nFused " << $game_variables[VAR_STAT_NB_FUSIONS].to_s << " Pokémon"
+  stringStats << _INTL("\nBeat the Elite Four {1} times",$game_variables[VAR_STAT_NB_ELITE_FOUR].to_s)
+  stringStats << _INTL("\nFused {1} Pokémon", $game_variables[VAR_STAT_NB_FUSIONS].to_s)
 
-  stringStats << "\nRematched " << $game_variables[VAR_STAT_LEADER_REMATCH].to_s << " Gym Leaders"
-  stringStats << "\nTook " << $PokemonGlobal.stepcount.to_s << " steps"
-  stringStats << "\nVisited " << countVisitedMaps.to_s << " different areas"
-  stringStats << "\nUsed " << $game_variables[VAR_STAT_RARE_CANDY] << " Rare Candies"
+  stringStats << _INTL("\nRematched {1} Gym Leaders",$game_variables[VAR_STAT_LEADER_REMATCH].to_s)
+  stringStats << _INTL("\nTook {1} steps",$PokemonGlobal.stepcount.to_s)
+  stringStats << _INTL("\nVisited {1} different areas",countVisitedMaps.to_s)
+  stringStats << _INTL("\nUsed {1} Rare Candies",$game_variables[VAR_STAT_RARE_CANDY])
 
   if $game_switches[910]
-    stringStats << "\nMade " << $game_variables[VAR_STAT_NB_WONDERTRADES].to_s << " Wonder Trades"
+    stringStats << _INTL("\nMade {1} Wonder Trades",$game_variables[VAR_STAT_NB_WONDERTRADES].to_s)
   end
 
-  stringStats << "\nTipped $" << $game_variables[VAR_STAT_CLOWN_TIP_TOTAL].to_s << " to clowns"
-  stringStats << "\nDestroyed " << $game_variables[VAR_STAT_NB_SANDCASTLES].to_s << " sandcastles"
-  stringStats << "\nReported " << $game_variables[VAR_NB_CRIMES_REPORTED].to_s << " crimes" if $game_variables[VAR_NB_CRIMES_REPORTED] > 0
+  stringStats << _INTL("\nTipped ${1} to clowns",$game_variables[VAR_STAT_CLOWN_TIP_TOTAL].to_s)
+  stringStats << _INTL("\nDestroyed {1} sandcastles",$game_variables[VAR_STAT_NB_SANDCASTLES].to_s)
+  stringStats << _INTL("\nReported {1} crimes",$game_variables[VAR_NB_CRIMES_REPORTED].to_s) if $game_variables[VAR_NB_CRIMES_REPORTED] > 0
 
 
   if $game_variables[VAR_STAT_GAMBLER_WINS] > 0 || $game_variables[VAR_STAT_GAMBLER_LOSSES] > 0
-    stringStats << "\nWon $" << $game_variables[VAR_STAT_GAMBLER_WINS].to_s << " against gamblers"
-    stringStats << "\nLost $" << $game_variables[VAR_STAT_GAMBLER_LOSSES].to_s << " against gamblers"
+    stringStats << _INTL("\nWon ${1} against gamblers",$game_variables[VAR_STAT_GAMBLER_WINS].to_s)
+    stringStats << _INTL("\nLost ${1} against gamblers",$game_variables[VAR_STAT_GAMBLER_LOSSES].to_s)
   end
-  stringStats << "\nSpent $" << $game_variables[VAR_STAT_HOTELS_SPENT].to_s << " at hotels"
+  stringStats << _INTL("\nSpent ${1} at hotels",$game_variables[VAR_STAT_HOTELS_SPENT].to_s)
 
-  stringStats << "\nAccepted " << $game_variables[VAR_STAT_QUESTS_ACCEPTED].to_s << " quests"
-  stringStats << "\nCompleted " << $game_variables[VAR_STAT_QUESTS_COMPLETED].to_s << " quests"
-  stringStats << "\nDiscovered " << $game_variables[VAR_STAT_NB_SECRETS].to_s << " secrets"
+  stringStats << _INTL("\nAccepted {1} quests",$game_variables[VAR_STAT_QUESTS_ACCEPTED].to_s)
+  stringStats << _INTL("\nCompleted {1} quests",$game_variables[VAR_STAT_QUESTS_COMPLETED].to_s)
+  stringStats << _INTL("\nDiscovered {1} secrets",$game_variables[VAR_STAT_NB_SECRETS].to_s)
 
   if $game_switches[912]
-    stringStats << "\nDied " << $game_variables[191].to_s << " times in Pikachu's adventure"
+    stringStats << _INTL("\nDied {1} times in Pikachu's adventure",$game_variables[191].to_s)
     if $game_variables[193] >= 1
-      stringStats << "\nCollected " << $game_variables[194].to_s << " coins with Pikachu"
+      stringStats << _INTL("\nCollected {1} coins with Pikachu",$game_variables[194].to_s)
     end
   end
   return stringStats
@@ -571,7 +571,7 @@ def Kernel.gymLeaderRematchHint()
     remaining_leaders << switch_nb unless $game_switches[switch_nb]
   end
   if remaining_leaders.empty?
-    return "You got every Gym Leader to come here. This place is more popular than ever!\nNow go and battle them!"
+    return _INTL("You got every Gym Leader to come here. This place is more popular than ever!\nNow go and battle them!")
   else
     key = remaining_leaders.sample
     return hints[key]

--- a/050_Outfits/UI/CharacterSelectMenuPresenter.rb
+++ b/050_Outfits/UI/CharacterSelectMenuPresenter.rb
@@ -1,23 +1,23 @@
 class CharacterSelectMenuPresenter
   attr_accessor :options
   attr_reader :current_index
-  OPTION_NAME = 'Name'
-  OPTION_AGE = "Age"
-  OPTION_GENDER = "Gender"
-  OPTION_HAIR = "Hair"
-  OPTION_SKIN = "Skin"
-  OPTION_CONFIRM = "Confirm"
+  OPTION_NAME = _INTL("Name")
+  OPTION_AGE = _INTL("Age")
+  OPTION_GENDER = _INTL("Gender")
+  OPTION_HAIR = _INTL("Hair")
+  OPTION_SKIN = _INTL("Skin")
+  OPTION_CONFIRM = _INTL("Confirm")
 
   MIN_AGE = 10
   MAX_AGE = 17
 
   MIN_SKIN_COLOR = 1
   MAX_SKIN_COLOR = 6
-  SKIN_COLOR_IDS = ["Type A", "Type B", "Type C", "Type D", "Type E", "Type F"]
-  GENDERS_IDS = ["Female", "Male"]
+  SKIN_COLOR_IDS = [_INTL("Type A"), _INTL("Type B"), _INTL("Type C"), _INTL("Type D"), _INTL("Type E"), _INTL("Type F")]
+  GENDERS_IDS = [_INTL("Female"), _INTL("Male")]
 
   HAIR_COLOR_IDS = [1, 2, 3, 4]
-  HAIR_COLOR_NAMES = ["Blonde", "Light Brown", "Dark Brown", "Black"]
+  HAIR_COLOR_NAMES = [_INTL("Blonde"), _INTL("Light Brown"), _INTL("Dark Brown"), _INTL("Black")]
 
   #ids for displayed text sprites
   NAME_TEXT_ID = "name"

--- a/050_Outfits/UI/LayeredClothes_Menus.rb
+++ b/050_Outfits/UI/LayeredClothes_Menus.rb
@@ -12,7 +12,7 @@ def selectHairstyle(all_unlocked = false)
   selector = OutfitSelector.new
   display_outfit_preview()
   hat = $Trainer.hat
-  commands = ["Next style", "Previous style", "Toggle hat", "Back"]
+  commands = [_INTL("Next style"), _INTL("Previous style"), _INTL("Toggle hat"), _INTL("Back")]
   previous_input = 0
   # To enable turning the common event that lets you turn around while in the dialog box
   while (true)
@@ -103,7 +103,7 @@ def selectHairColor
   display_outfit_preview()
   hat = $Trainer.hat
   hat2 = $Trainer.hat2
-  commands = ["Swap base color", "Shift up", "Shift down", "Toggle hat", "Remove dye", "Confirm", "Never Mind"]
+  commands = [_INTL("Swap base color"), _INTL("Shift up"), _INTL("Shift down"), _INTL("Toggle hat"), _INTL("Remove dye"), _INTL("Confirm"), _INTL("Never Mind")]
   previous_input = 0
 
   while (true)
@@ -161,7 +161,7 @@ end
 def selectHatColor(secondary_hat=false)
   original_color = secondary_hat ? $Trainer.hat2_color : $Trainer.hat_color
   display_outfit_preview()
-  commands = ["Shift up", "Shift down", "Reset", "Confirm", "Never Mind"]
+  commands = [_INTL("Shift up"), _INTL("Shift down"), _INTL("Reset"), _INTL("Confirm"), _INTL("Never Mind")]
   previous_input = 0
   while (true)
     choice = pbShowCommands(nil, commands, commands.length, previous_input)
@@ -201,7 +201,7 @@ end
 def selectClothesColor
   original_color = $Trainer.clothes_color
   display_outfit_preview()
-  commands = ["Shift up", "Shift down", "Reset", "Confirm", "Never Mind"]
+  commands = [_INTL("Shift up"), _INTL("Shift down"), _INTL("Reset"), _INTL("Confirm"), _INTL("Never Mind")]
   previous_input = 0
   ret = false
   while (true)
@@ -240,7 +240,7 @@ end
 def selectHat(all_unlocked = false)
   selector = OutfitSelector.new
   display_outfit_preview()
-  commands = ["Next hat", "Previous hat", "Remove hat", "Back"]
+  commands = [_INTL("Next hat"), _INTL("Previous hat"), _INTL("Remove hat"), _INTL("Back")]
   previous_input = 0
   while (true)
     choice = pbShowCommands(nil, commands, commands.length, previous_input)
@@ -273,10 +273,10 @@ end
 def selectClothes(all_unlocked = false)
   selector = OutfitSelector.new
   display_outfit_preview()
-  commands = ["Next", "Previous"]
+  commands = [_INTL("Next"), _INTL("Previous")]
   #commands << "Remove clothes (DEBUG)" if $DEBUG
-  commands << "Remove" if $DEBUG
-  commands << "Back"
+  commands << _INTL("Remove") if $DEBUG
+  commands << _INTL("Back")
   previous_input = 0
   while (true)
     choice = pbShowCommands(nil, commands, commands.length, previous_input)

--- a/050_Outfits/UI/clothesShop/ClothesShopView.rb
+++ b/050_Outfits/UI/clothesShop/ClothesShopView.rb
@@ -1,6 +1,6 @@
 class ClothesShopView < PokemonMart_Scene
 
-  def initialize(currency_name = "Money")
+  def initialize(currency_name = _INTL("Money"))
     @currency_name = currency_name
     @currency_name = COSMETIC_CURRENCY_NAME if Settings::HOENN
   end

--- a/050_Outfits/UI/clothesShop/HatShopView.rb
+++ b/050_Outfits/UI/clothesShop/HatShopView.rb
@@ -2,7 +2,7 @@
 
 class HatShopView < ClothesShopView
 
-  def initialize(currency_name = "Money")
+  def initialize(currency_name = _INTL("Money"))
     @currency_name = currency_name
   end
 

--- a/050_Outfits/UI/hairMenu/HairStyleSelectionMenuView.rb
+++ b/050_Outfits/UI/hairMenu/HairStyleSelectionMenuView.rb
@@ -73,7 +73,7 @@ class HairStyleSelectionMenuView
   end
 
   def init_labels()
-    Kernel.pbDisplayText("Confirm", (CONFIRM_X+CURSOR_X_MARGIN), CONFIRM_Y)
+    Kernel.pbDisplayText(_INTL("Confirm"), (CONFIRM_X+CURSOR_X_MARGIN), CONFIRM_Y)
   end
 
 

--- a/050_Outfits/UI/hairMenu/HairstyleSelectionMenuPresenter.rb
+++ b/050_Outfits/UI/hairMenu/HairstyleSelectionMenuPresenter.rb
@@ -2,11 +2,11 @@ class HairstyleSelectionMenuPresenter
   attr_accessor :options
   attr_reader :current_index
 
-  OPTION_STYLE = 'Hairstyle'
-  OPTION_BASE_COLOR = "Base color"
-  OPTION_DYE = "Dye"
+  OPTION_STYLE = _INTL("Hairstyle")
+  OPTION_BASE_COLOR = _INTL("Base color")
+  OPTION_DYE = _INTL("Dye")
 
-  HAIR_COLOR_NAMES = ["Blonde", "Light Brown", "Dark Brown", "Black"]
+  HAIR_COLOR_NAMES = [_INTL("Blonde"), _INTL("Light Brown"), _INTL("Dark Brown"), _INTL("Black")]
   HAIR_COLOR_IDS = [1, 2, 3, 4]
 
   #ids for displayed text sprites

--- a/052_InfiniteFusion/Fusion/Credits/SpriteCreditsUtils.rb
+++ b/052_InfiniteFusion/Fusion/Credits/SpriteCreditsUtils.rb
@@ -241,7 +241,7 @@ def displayTeamFlag(frame)
   $game_screen.pictures[flag_image_id].show(flag_path, 0, x_position, y_position, 50, 50)
   $game_screen.pictures[frame_image_id].show("teamFlagFrame", 0, x_position, y_position, 50, 50)
   name = species.real_name
-  pbMessage("\"Team #{name} Flag\"")
+  pbMessage(_INTL("\"Team {1} Flag\"",name))
 
   display_team_flag_statistics(species)
 
@@ -429,7 +429,7 @@ def displayGalleryFrame(frame)
   $game_screen.pictures[bg_image_id].show("pictureFrame", 0, 0, 0)
   name = species.real_name
   author = pbGet(259)
-  message = "\"#{name}\"\nBy #{author}"
+  message = _INTL("\"{1}\"\nBy {2}",name,author)
   displaySpriteWindowWithMessage(pif_sprite, message, 90, -10, 201)
   $game_screen.pictures[frame_image_id].erase
   $game_screen.pictures[bg_image_id].erase

--- a/052_InfiniteFusion/Gameplay/Pokedex/UI_Pokedex_SpritesPage.rb
+++ b/052_InfiniteFusion/Gameplay/Pokedex/UI_Pokedex_SpritesPage.rb
@@ -617,8 +617,8 @@ class PokemonPokedexInfo_Scene
           pbMessage(_INTL("This sprite is already the displayed sprite"))
         end
       else
-        message = _INTL('Would you like to use this sprite instead of the current sprite?')
-        message = _INTL('Would you like to use this sprite instead of the current sprite for the entire species?') unless @pokemon
+        message = _INTL("Would you like to use this sprite instead of the current sprite?")
+        message = _INTL("Would you like to use this sprite instead of the current sprite for the entire species?") unless @pokemon
         if pbConfirmMessage(message)
           swap_main_sprite()
           return true

--- a/052_InfiniteFusion/Gameplay/Quests/TRQuests.rb
+++ b/052_InfiniteFusion/Gameplay/Quests/TRQuests.rb
@@ -79,8 +79,8 @@ def finishTRQuest(id, status, silent = false)
   return if pbCompletedQuest?(id)
   pbMEPlay("Register phone") if status == :SUCCESS && !silent
   pbMEPlay("Voltorb Flip Game Over") if status == :FAILURE && !silent
-  Kernel.pbMessage("\\C[2]Mission completed!") if status == :SUCCESS && !silent
-  Kernel.pbMessage("\\C[2]Mission Failed...") if status == :FAILURE && !silent
+  Kernel.pbMessage(_INTL("\\C[2]Mission completed!")) if status == :SUCCESS && !silent
+  Kernel.pbMessage(_INTL("\\C[2]Mission Failed...")) if status == :FAILURE && !silent
 
   $game_variables[VAR_KARMA] -= 5 # karma
   $game_variables[VAR_NB_ROCKET_MISSIONS] += 1 #nb. quests completed

--- a/052_InfiniteFusion/System/Game Options/SystemOptions.rb
+++ b/052_InfiniteFusion/System/Game Options/SystemOptions.rb
@@ -118,7 +118,7 @@ class SystemOptionsScene < PokemonOption_Scene
     options << EnumOption.new(_INTL("Device"), [_INTL("PC"), _INTL("Mobile")],
                               proc { device_option_selected },
                               proc { |value| $PokemonSystem.on_mobile = value == 1 },
-                              ["The intended device on which to play the game.",
+                              [_INTL("The intended device on which to play the game."),
                                _INTL("Disables some options that aren't supported when playing on mobile.")]
     )
 

--- a/052_InfiniteFusion/System/MultiSaves.rb
+++ b/052_InfiniteFusion/System/MultiSaves.rb
@@ -510,8 +510,8 @@ class PokemonLoadScreen
         commands[commands.length] = _INTL(key)
       end
 
-      # commands[cmd_discord = commands.length] = _INTL('Discord')
-      # commands[cmd_wiki = commands.length] = _INTL('Wiki')
+      # commands[cmd_discord = commands.length] = _INTL("Discord")
+      # commands[cmd_wiki = commands.length] = _INTL("Wiki")
       commands[cmd_savefile = commands.length] = _INTL("Savefile management") if show_continue
       commands[cmd_debug = commands.length] = _INTL("Debug") if $DEBUG
       commands[cmd_quit = commands.length] = _INTL("Quit Game")

--- a/052_InfiniteFusion/System/MultiSaves.rb
+++ b/052_InfiniteFusion/System/MultiSaves.rb
@@ -496,7 +496,7 @@ class PokemonLoadScreen
         commands[cmd_new_game_plus = commands.length] = _INTL("New Game +")
       end
       commands[cmd_options = commands.length] = _INTL("Options")
-      commands[cmd_language = commands.length] = _INTL("Language") if Settings::LANGUAGES[Settings::GAME_ID].length >= 2
+      commands[cmd_language = commands.length] = _INTL("Language") if Settings::LANGUAGES.length >= 2
 
       cmd_links = {}
 

--- a/052_InfiniteFusion/System/MultiSaves.rb
+++ b/052_InfiniteFusion/System/MultiSaves.rb
@@ -487,16 +487,16 @@ class PokemonLoadScreen
       if show_continue
         commands[cmd_continue = commands.length] = "#{@selected_file}"
         #if @save_data[:player].mystery_gift_unlocked
-        commands[cmd_mystery_gift = commands.length] = _INTL('Mystery Gift') # Honestly I have no idea how to make Mystery Gift work well with this.
+        commands[cmd_mystery_gift = commands.length] = _INTL("Mystery Gift") # Honestly I have no idea how to make Mystery Gift work well with this.
         #end
       end
 
-      commands[cmd_new_game = commands.length] = _INTL('New Game')
+      commands[cmd_new_game = commands.length] = _INTL("New Game")
       if new_game_plus
-        commands[cmd_new_game_plus = commands.length] = _INTL('New Game +')
+        commands[cmd_new_game_plus = commands.length] = _INTL("New Game +")
       end
-      commands[cmd_options = commands.length] = _INTL('Options')
-      commands[cmd_language = commands.length] = _INTL('Language') if Settings::LANGUAGES[Settings::GAME_ID].length >= 2
+      commands[cmd_options = commands.length] = _INTL("Options")
+      commands[cmd_language = commands.length] = _INTL("Language") if Settings::LANGUAGES[Settings::GAME_ID].length >= 2
 
       cmd_links = {}
 
@@ -512,9 +512,9 @@ class PokemonLoadScreen
 
       # commands[cmd_discord = commands.length] = _INTL('Discord')
       # commands[cmd_wiki = commands.length] = _INTL('Wiki')
-      commands[cmd_savefile = commands.length] = _INTL('Savefile management') if show_continue
-      commands[cmd_debug = commands.length] = _INTL('Debug') if $DEBUG
-      commands[cmd_quit = commands.length] = _INTL('Quit Game')
+      commands[cmd_savefile = commands.length] = _INTL("Savefile management") if show_continue
+      commands[cmd_debug = commands.length] = _INTL("Debug") if $DEBUG
+      commands[cmd_quit = commands.length] = _INTL("Quit Game")
       cmd_left = -3
       cmd_right = -2
 
@@ -739,7 +739,7 @@ class PokemonSaveScreen
         _INTL("Save to another slot"),
         _INTL("Don't save")
       ]
-      opt = pbMessage(_INTL('Would you like to save the game?'), choices, 3)
+      opt = pbMessage(_INTL("Would you like to save the game?"), choices, 3)
       if opt == 0
         pbSEPlay('GUI save choice')
         ret = doSave($Trainer.save_slot)

--- a/052_InfiniteFusion/System/MultiSaves.rb
+++ b/052_InfiniteFusion/System/MultiSaves.rb
@@ -496,7 +496,7 @@ class PokemonLoadScreen
         commands[cmd_new_game_plus = commands.length] = _INTL("New Game +")
       end
       commands[cmd_options = commands.length] = _INTL("Options")
-      commands[cmd_language = commands.length] = _INTL("Language") if Settings::LANGUAGES.length >= 2
+      commands[cmd_language = commands.length] = _INTL("Language") if Settings::LANGUAGES[Settings::GAME_ID].length >= 2
 
       cmd_links = {}
 

--- a/053_PIF_Hoenn/PokeNav/PokeRadarHoenn/PokeRadarAppScene.rb
+++ b/053_PIF_Hoenn/PokeNav/PokeRadarHoenn/PokeRadarAppScene.rb
@@ -324,7 +324,7 @@ class PokeRadarAppScene < PokeNavAppScene
     return unless @unseenPokemon.any?
     Kernel.pbClearText()
     showHeaderInfo
-    pbMessage(_INTL('You need to encounter the Pokémon before you can scan for it.'))
+    pbMessage(_INTL("You need to encounter the Pokémon before you can scan for it."))
     hover_unseen
   end
 


### PR DESCRIPTION
1. [007_Objects and windows/011_Messages.rb]

    Fix the display of translated map names on the main interface for the translated version. Similar to PR #14 
    before
    <img width="816" height="81" alt="011_Messages rb map name before" src="https://github.com/user-attachments/assets/3ce3485c-9c8c-4411-959d-ce0a36b61103" />
    after
    <img width="816" height="90" alt="011_Messages rb map name after" src="https://github.com/user-attachments/assets/a3af5a7d-4a75-4e3b-a8e4-acc977753c48" />

2. Other changes:

    There are still some formatting issues in the Scripts folder that prevent certain texts from being extracted during intl extraction.
    Based on the current version, I've ported the missing _INTL markers and double‑quote fixes from PR #12 . Should basically cover the issue. Should be safe to merge.


