### PR TITLE
Translation-Fix4

### DIFF
--- a/011_Battle/003_BattleHandlers_Abilities.rb
+++ b/011_Battle/003_BattleHandlers_Abilities.rb
@@ -497,14 +497,14 @@ BattleHandlers::StatLossImmunityAllyAbility.add(:FLOWERVEIL,
 BattleHandlers::AbilityOnStatLoss.add(:COMPETITIVE,
   proc { |ability,battler,stat,user|
     next if user && !user.opposes?(battler)
-    battler.pbRaiseStatStageByAbility(:SPECIAL_ATTACK,2,battler,GameData::Ability.get(ability).real_name)
+    battler.pbRaiseStatStageByAbility(:SPECIAL_ATTACK,2,battler,GameData::Ability.get(ability).name)
   }
 )
 
 BattleHandlers::AbilityOnStatLoss.add(:DEFIANT,
   proc { |ability,battler,stat,user|
     next if user && !user.opposes?(battler)
-    battler.pbRaiseStatStageByAbility(:ATTACK,2,battler,GameData::Ability.get(ability).real_name)
+    battler.pbRaiseStatStageByAbility(:ATTACK,2,battler,GameData::Ability.get(ability).name)
   }
 )
 
@@ -555,7 +555,7 @@ BattleHandlers::PriorityBracketChangeAbility.add(:STALL,
 
 BattleHandlers::AbilityOnFlinch.add(:STEADFAST,
   proc { |ability,battler,battle|
-    battler.pbRaiseStatStageByAbility(:SPEED,1,battler,GameData::Ability.get(ability).real_name)
+    battler.pbRaiseStatStageByAbility(:SPEED,1,battler,GameData::Ability.get(ability).name)
   }
 )
 
@@ -1441,7 +1441,7 @@ BattleHandlers::TargetAbilityOnHit.add(:FLAMEBODY,
 BattleHandlers::TargetAbilityOnHit.add(:GOOEY,
   proc { |ability,user,target,move,battle|
     next if !move.pbContactMove?(user)
-    user.pbLowerStatStageByAbility(:SPEED,1,target,true,true,GameData::Ability.get(ability).real_name)
+    user.pbLowerStatStageByAbility(:SPEED,1,target,true,true,GameData::Ability.get(ability).name)
   }
 )
 
@@ -1500,7 +1500,7 @@ BattleHandlers::TargetAbilityOnHit.copy(:IRONBARBS,:ROUGHSKIN)
 BattleHandlers::TargetAbilityOnHit.add(:JUSTIFIED,
   proc { |ability,user,target,move,battle|
     next if move.calcType != :DARK
-    target.pbRaiseStatStageByAbility(:ATTACK,1,target,GameData::Ability.get(ability).real_name)
+    target.pbRaiseStatStageByAbility(:ATTACK,1,target,GameData::Ability.get(ability).name)
   }
 )
 
@@ -1549,13 +1549,13 @@ BattleHandlers::TargetAbilityOnHit.add(:POISONPOINT,
 BattleHandlers::TargetAbilityOnHit.add(:RATTLED,
   proc { |ability,user,target,move,battle|
     next if ![:BUG, :DARK, :GHOST].include?(move.calcType)
-    target.pbRaiseStatStageByAbility(:SPEED,1,target,GameData::Ability.get(ability).real_name)
+    target.pbRaiseStatStageByAbility(:SPEED,1,target,GameData::Ability.get(ability).name)
   }
 )
 
 BattleHandlers::TargetAbilityOnHit.add(:STAMINA,
   proc { |ability,user,target,move,battle|
-    target.pbRaiseStatStageByAbility(:DEFENSE,1,target,GameData::Ability.get(ability).real_name)
+    target.pbRaiseStatStageByAbility(:DEFENSE,1,target,GameData::Ability.get(ability).name)
   }
 )
 
@@ -1580,7 +1580,7 @@ BattleHandlers::TargetAbilityOnHit.add(:STATIC,
 BattleHandlers::TargetAbilityOnHit.add(:WATERCOMPACTION,
   proc { |ability,user,target,move,battle|
     next if move.calcType != :WATER
-    target.pbRaiseStatStageByAbility(:DEFENSE,2,target,GameData::Ability.get(ability).real_name)
+    target.pbRaiseStatStageByAbility(:DEFENSE,2,target,GameData::Ability.get(ability).name)
   }
 )
 
@@ -1590,9 +1590,9 @@ BattleHandlers::TargetAbilityOnHit.add(:WEAKARMOR,
     next if !target.pbCanLowerStatStage?(:DEFENSE, target) &&
             !target.pbCanRaiseStatStage?(:SPEED, target)
     battle.pbShowAbilitySplash(target)
-    target.pbLowerStatStageByAbility(:DEFENSE, 1, target, false,GameData::Ability.get(ability).real_name)
+    target.pbLowerStatStageByAbility(:DEFENSE, 1, target, false,GameData::Ability.get(ability).name)
     target.pbRaiseStatStageByAbility(:SPEED,
-       (Settings::MECHANICS_GENERATION >= 7) ? 2 : 1, target, false,GameData::Ability.get(ability).real_name)
+       (Settings::MECHANICS_GENERATION >= 7) ? 2 : 1, target, false,GameData::Ability.get(ability).name)
     battle.pbHideAbilitySplash(target)
   }
 )
@@ -1639,7 +1639,7 @@ BattleHandlers::UserAbilityEndOfMove.add(:BEASTBOOST,
     GameData::Stat.each_main_battle do |s|
       next if userStats[s.id] < highestStatValue
       if user.pbCanRaiseStatStage?(s.id, user)
-        user.pbRaiseStatStageByAbility(s.id, numFainted, user,GameData::Ability.get(ability).real_name)
+        user.pbRaiseStatStageByAbility(s.id, numFainted, user,GameData::Ability.get(ability).name)
       end
       break
     end
@@ -1692,7 +1692,7 @@ BattleHandlers::UserAbilityEndOfMove.add(:MOXIE,
     numFainted = 0
     targets.each { |b| numFainted += 1 if b.damageState.fainted }
     next if numFainted==0 || !user.pbCanRaiseStatStage?(:ATTACK,user)
-    user.pbRaiseStatStageByAbility(:ATTACK,numFainted,user,GameData::Ability.get(ability).real_name)
+    user.pbRaiseStatStageByAbility(:ATTACK,numFainted,user,GameData::Ability.get(ability).name)
   }
 )
 
@@ -1705,7 +1705,7 @@ BattleHandlers::TargetAbilityAfterMoveUse.add(:BERSERK,
     next if !move.damagingMove?
     next if target.damageState.initialHP<target.totalhp/2 || target.hp>=target.totalhp/2
     next if !target.pbCanRaiseStatStage?(:SPECIAL_ATTACK,target)
-    target.pbRaiseStatStageByAbility(:SPECIAL_ATTACK,1,target,GameData::Ability.get(ability).real_name)
+    target.pbRaiseStatStageByAbility(:SPECIAL_ATTACK,1,target,GameData::Ability.get(ability).name)
   }
 )
 
@@ -1947,12 +1947,12 @@ BattleHandlers::EOREffectAbility.add(:MOODY,
     battle.pbShowAbilitySplash(battler)
     if randomUp.length>0
       r = battle.pbRandom(randomUp.length)
-      battler.pbRaiseStatStageByAbility(randomUp[r],2,battler,false,GameData::Ability.get(ability).real_name)
+      battler.pbRaiseStatStageByAbility(randomUp[r],2,battler,false,GameData::Ability.get(ability).name)
       randomDown.delete(randomUp[r])
     end
     if randomDown.length>0
       r = battle.pbRandom(randomDown.length)
-      battler.pbLowerStatStageByAbility(randomDown[r],1,battler,false,GameData::Ability.get(ability).real_name)
+      battler.pbLowerStatStageByAbility(randomDown[r],1,battler,false,GameData::Ability.get(ability).name)
     end
     battle.pbHideAbilitySplash(battler)
     battler.pbItemStatRestoreCheck if randomDown.length>0
@@ -1964,7 +1964,7 @@ BattleHandlers::EOREffectAbility.add(:SPEEDBOOST,
     # A Pokémon's turnCount is 0 if it became active after the beginning of a
     # round
     if battler.turnCount>0 && battler.pbCanRaiseStatStage?(:SPEED,battler)
-      ability_name = GameData::Ability.get(ability).real_name
+      ability_name = GameData::Ability.get(ability).name
       battler.pbRaiseStatStageByAbility(:SPEED,1,battler,true,ability_name)
     end
   }
@@ -2142,7 +2142,7 @@ BattleHandlers::AbilityOnSwitchIn.add(:DOWNLOAD,
       oSpDef += b.spdef
     end
     stat = (oDef<oSpDef) ? :ATTACK : :SPECIAL_ATTACK
-    battler.pbRaiseStatStageByAbility(stat,1,battler,GameData::Ability.get(ability).real_name)
+    battler.pbRaiseStatStageByAbility(stat,1,battler,GameData::Ability.get(ability).name)
   }
 )
 
@@ -2411,7 +2411,7 @@ BattleHandlers::AbilityChangeOnBattlerFainting.copy(:POWEROFALCHEMY,:RECEIVER)
 
 BattleHandlers::AbilityOnBattlerFainting.add(:SOULHEART,
   proc { |ability,battler,fainted,battle|
-    battler.pbRaiseStatStageByAbility(:SPECIAL_ATTACK,1,battler,GameData::Ability.get(ability).real_name)
+    battler.pbRaiseStatStageByAbility(:SPECIAL_ATTACK,1,battler,GameData::Ability.get(ability).name)
   }
 )
 

--- a/020_Debug/001_Editor_Utilities.rb
+++ b/020_Debug/001_Editor_Utilities.rb
@@ -134,7 +134,7 @@ def pbChooseSpeciesTextList(default = nil)
   commands = []
   for i in 1..NB_POKEMON-4
     species = GameData::Species.get(i)
-    commands.push([species.id_number, species.real_name, species.id])
+    commands.push([species.id_number, species.name, species.id])
   end
   return pbChooseList(commands, default, nil, -1)
 end
@@ -143,7 +143,7 @@ end
 def pbChooseSpeciesFormList(default = nil)
   commands = []
   GameData::Species.each do |s|
-    name = (s.form == 0) ? s.real_name : sprintf("%s_%d", s.real_name, s.form)
+    name = (s.form == 0) ? s.real_name : sprintf("%s_%d", s.name, s.form)
     commands.push([s.id_number, name, s.id])
   end
   return pbChooseList(commands, default, nil, -1)

--- a/049_Compatibility/PBSpecies.rb
+++ b/049_Compatibility/PBSpecies.rb
@@ -5,7 +5,7 @@ module PBSpecies
   end
 
   def PBSpecies.getName(species)
-    return GameData::Species.get(species).real_name
+    return GameData::Species.get(species).name
   end
 
 #In some places, pokemon are instanciated as PBSpecies::NAME in wild battles, trades, etc. which doesn't work anymore.

--- a/052_InfiniteFusion/Fusion/Menus/FusionMovesMenu.rb
+++ b/052_InfiniteFusion/Fusion/Menus/FusionMovesMenu.rb
@@ -264,7 +264,7 @@ class FusionMovesOptionsScene < PokemonOption_Scene
         # Header row — show pokemon info panel
         draw_pokemon_info
         species = col == 0 ? @head_species : @body_species
-        @sprites["textbox"].text = _INTL("\nSelect all moves from {1}", GameData::Species.get(species).real_name)
+        @sprites["textbox"].text = _INTL("\nSelect all moves from {1}", GameData::Species.get(species).name)
         return
       end
 
@@ -337,8 +337,8 @@ class FusionMovesOptionsScene < PokemonOption_Scene
     )
 
     move_options = @move_slots.map do |slot|
-      left_name = slot[0] ? GameData::Move.get(slot[0].id).real_name : "-"
-      right_name = slot[1] ? GameData::Move.get(slot[1].id).real_name : "-"
+      left_name = slot[0] ? GameData::Move.get(slot[0].id).name : "-"
+      right_name = slot[1] ? GameData::Move.get(slot[1].id).name : "-"
       EnumOption.new(
         "",
         [left_name, right_name],
@@ -581,5 +581,4 @@ class Window_PokemonOptionFusionMoves < Window_PokemonOption
       refresh
     end
   end
-
 end

--- a/052_InfiniteFusion/Gameplay/0_Utilities/GraphicsUtils.rb
+++ b/052_InfiniteFusion/Gameplay/0_Utilities/GraphicsUtils.rb
@@ -43,17 +43,16 @@ def addShinyStarsToGraphicsArray(imageArray, xPos, yPos, shinyBody, shinyHead, d
 end
 
 def pbBitmap(path)
-  if !pbResolveBitmap(path).nil?
-    bmp = RPG::Cache.load_bitmap_path(path)
-    bmp.storedPath = path
+  resolved_path = pbResolveBitmap(path)
+  if !resolved_path.nil?
+    bmp = RPG::Cache.load_bitmap_path(resolved_path)
+    bmp.storedPath = resolved_path
   else
     p "Image located at '#{path}' was not found!" if $DEBUG
     bmp = Bitmap.new(1, 1)
   end
   return bmp
 end
-
-
 
 # if need to play animation from event route
 def playAnimation(animationId, x = nil, y = nil)

--- a/053_PIF_Hoenn/Gameplay/Quests/QuestMapPopup.rb
+++ b/053_PIF_Hoenn/Gameplay/Quests/QuestMapPopup.rb
@@ -103,6 +103,7 @@ class QuestMapPopup
 
       # Text/icon overlay bitmap
       s = BitmapSprite.new(PANEL_WIDTH - 12, ITEM_HEIGHT - 4, @viewport)
+      pbSetSystemFont(s.bitmap)
       s.x = panel_x + 6
       s.y = (Graphics.height - PANEL_HEIGHT) / 2 + 36 + i * ITEM_HEIGHT
       s.z = 110003

--- a/053_PIF_Hoenn/Gameplay/Quests/QuestsMap.rb
+++ b/053_PIF_Hoenn/Gameplay/Quests/QuestsMap.rb
@@ -218,7 +218,7 @@ class QuestMap < BetterRegionMap
     nb_quests_at_position = 0
     nb_quests_at_position = @quests[current_position].length if quests_at_location
     text = ""
-    text = location[2] if location
+    text = pbGetMessageFromHash(MessageTypes::PlaceNames, location[2]) if location
 
     nb_quests_text = ""
     if nb_quests_at_position > 1

--- a/053_PIF_Hoenn/PokeNav/Challenges/Challenges.rb
+++ b/053_PIF_Hoenn/PokeNav/Challenges/Challenges.rb
@@ -123,15 +123,15 @@ class PlayerChallenge
   end
 
   def description
-    return @template.description
+    _INTL(@template.description)
   end
 
   def category
-    return @template.category
+    _INTL(@template.category)
   end
 
   def money_reward
-    return @template.money_reward
+    _INTL(@template.money_reward)
   end
 end
 

--- a/053_PIF_Hoenn/PokeNav/Challenges/Challenges.rb
+++ b/053_PIF_Hoenn/PokeNav/Challenges/Challenges.rb
@@ -123,15 +123,15 @@ class PlayerChallenge
   end
 
   def description
-    _INTL(@template.description)
+    return _INTL(@template.description)
   end
 
   def category
-    _INTL(@template.category)
+    return _INTL(@template.category)
   end
 
   def money_reward
-    _INTL(@template.money_reward)
+    return _INTL(@template.money_reward)
   end
 end
 

--- a/053_PIF_Hoenn/PokeNav/PokeRadarHoenn/PokeRadarAppScene.rb
+++ b/053_PIF_Hoenn/PokeNav/PokeRadarHoenn/PokeRadarAppScene.rb
@@ -116,7 +116,7 @@ class PokeRadarAppScene < PokeNavAppScene
     bmp = load_bitmap(icon_path, false)
     button = PokenavButton.new(scanningPokemon, bmp)
     button.refresh
-    species_name = GameData::Species.get(scanningPokemon).real_name
+    species_name = GameData::Species.get(scanningPokemon).name
     Kernel.pbDisplayText(_INTL("Currently scanning for {1}.", species_name), Graphics.width / 2, 200, 500000, @text_color_base, @text_color_shadow)
     Kernel.pbDisplayText(_INTL("Current chain: {1}.", $PokemonTemp.pokeradar[2]), Graphics.width / 2, 230, 500000, @text_color_base, @text_color_shadow)
     return [button]
@@ -295,7 +295,7 @@ class PokeRadarAppScene < PokeNavAppScene
         max_level = encounter[3]
         level = rand(min_level..max_level)
         pbWait(16)
-        pbMessage(_INTL("Scanning for {1}...\\wtnp[5]", GameData::Species.get(species).real_name))
+        pbMessage(_INTL("Scanning for {1}...\\wtnp[5]", GameData::Species.get(species).name))
         possible_tiles = getTerrainTilesNearPlayer(getTerrainType, 3)
         position = possible_tiles.sample
         if position
@@ -330,7 +330,7 @@ class PokeRadarAppScene < PokeNavAppScene
 
   def hover_seen(species)
     displayTextElements
-    pokemon_name = GameData::Species.get(species).real_name
+    pokemon_name = GameData::Species.get(species).name
     Kernel.pbDisplayText(pokemon_name, Graphics.width / 2, INFO_TEXT_Y, 99999, @text_color_base, @text_color_shadow)
     Kernel.pbDisplayText(get_rarity_flavor_text(species), Graphics.width / 2, INFO_TEXT_Y + 30, 99999, @text_color_base, @text_color_shadow)
     Kernel.pbDisplayText(_INTL("Battery for scan: {1}", get_energy_for_scan(species)), Graphics.width / 2, INFO_TEXT_Y + 60, 99999, @text_color_base, @text_color_shadow)


### PR DESCRIPTION
Hi, I feel you've been too busy to check messages. I'll put here the known cases where translated text doesn't display correctly. In these cases, indeed some of them require changing real_name to name. Due to my limited technical ability, I can only make these changes in this way. If you have a better approach, then this PR can serve as a way to help you locate the problem areas.

All commits are tested in game.

1. Fix: Ensure translation text in Choosing different starters
    [020_Debug/001_Editor_Utilities.rb]
    <img width="1026" height="814" alt="1" src="https://github.com/user-attachments/assets/317afdb5-c4b6-4123-a5b1-195524f8d75a" />

2. Fix: Ensure the display of translation text after Choosing a different starters
    [049_Compatibility/PBSpecies.rb]
    <img width="1026" height="814" alt="image" src="https://github.com/user-attachments/assets/20c2e422-c371-4a90-9416-48bdba98eb1e" />


2. Fix: Ensure display of translation when choosing fusion's moves & name
    [052_InfiniteFusion/Fusion/Menus/FusionMovesMenu.rb]
    <img width="1026" height="814" alt="2" src="https://github.com/user-attachments/assets/0c8399b1-0e1d-4e0f-802c-32e57c5fb7c9" />
    
3. Fix: Ensure the display of translated images(Presskey&Logo) in Graphics\Localized\zh\Titles
    [052_InfiniteFusion/Gameplay/0_Utilities/GraphicsUtils.rb] 
    <img width="1026" height="814" alt="image" src="https://github.com/user-attachments/assets/44efdf48-d2b0-44b1-abfc-fb6aa5daf847" />

4. Fix: Ensure Quest related translation
    [053_PIF_Hoenn/Gameplay/Quests/QuestsMap.rb]
    [053_PIF_Hoenn/Gameplay/Quests/QuestMapPopup.rb] 
    <img width="1026" height="814" alt="image" src="https://github.com/user-attachments/assets/9dd5d88b-c9ae-4b88-8101-94f4c66dac66" />
    <img width="1026" height="814" alt="image" src="https://github.com/user-attachments/assets/2e47c699-8014-4559-84e9-a81f1e0470a9" />

5.  Fix: Ensure the display of translation text in PokeChallenge 
    [053_PIF_Hoenn/PokeNav/Challenges/Challenges.rb]
    <img width="1026" height="814" alt="image" src="https://github.com/user-attachments/assets/8692fde4-2468-43c7-a1c0-8f8f0da40a03" />
    

6. Fix: Ensure ability banner translations display correctly in battle
    [011_Battle/003_BattleHandlers_Abilities.rb]
    <img width="514" height="430" alt="image" src="https://github.com/user-attachments/assets/4d68b87e-6499-4ee9-a7b2-e36b0d09dd63" />
    

7. Fix: Ensure Pokemon names in the PokeRadar interface display translated text
    [053_PIF_Hoenn/PokeNav/PokeRadarHoenn/PokeRadarAppScene.rb]
    <img width="1026" height="814" alt="image" src="https://github.com/user-attachments/assets/d3ef5059-018d-4221-be7d-d6fc812b29a7" />


    
I'm aware that you may not be in favor of the real_name to name replacements, so I'll just report these issues for now.

