### PR TITLE
Bug-fix: Fling

### DIFF
--- a/011_Battle/002_Move/006_Move_Effects_080-0FF.rb
+++ b/011_Battle/002_Move/006_Move_Effects_080-0FF.rb
@@ -3534,6 +3534,7 @@ class PokeBattle_Move_0F7 < PokeBattle_Move
     @willFail = true if user.item.is_berry? && !user.canConsumeBerry?
     return if @willFail
     return if user.item.is_mega_stone?
+    return if user.item.is_berry? 
     flingableItem = false
     @flingPowers.each do |_power, items|
       next if !items.include?(user.item_id)


### PR DESCRIPTION
Fix the bug where Fling fails when used while holding a Berry.
flingableItem starts false. The code loops through @flingPowers looking for the user's held item; if found, it sets flingableItem to true. If not, it stays false, and the move fails (@willFail = true)
Berries aren't listed in any of the @flingPowers arrays, so the loop can't find them, flingableItem stays false, and @willFail ends up as true, causing the move to fail.