### PR TITLE
Fix Lance's Blissey/Goodra's ability and nature

### DIFF
--- a/054_PIF_Kanto/EliteFourRematches/E4TrainersData.rb
+++ b/054_PIF_Kanto/EliteFourRematches/E4TrainersData.rb
@@ -118,7 +118,7 @@ E4_POKEMON_POOL = {
     {:species => [:PORYGONZ,:NOIVERN],  :level => 5, :ability => :ADAPTABILITY,  :nature => :MODEST,   :moves => [:BOOMBURST,:DRAGONCLAW,:TRIATTACK,:WHIRLWIND],     :item => :ASSAULTVEST, :tier => 4},
 
     #TIER 5
-    {:species => [:BLISSEY,:GOODRA],  :level => 8, :ability => :ADAPTABILITY,  :nature => :NATURALCURE,   :moves => [:RECOVER,:CALMMIND,:DRAGONPULSE,:FLAMETHROWER],     :item => :CHOPLEBERRY, :tier => 5},
+    {:species => [:BLISSEY,:GOODRA],  :level => 8, :ability => :NATURALCURE,  :nature => :DOCILE,   :moves => [:RECOVER,:CALMMIND,:DRAGONPULSE,:FLAMETHROWER],     :item => :CHOPLEBERRY, :tier => 5},
     {:species => [:URSARING,:DRAGONITE],  :level => 6, :ability => :GUTS,  :nature => :ADAMANT,   :moves => [:SWORDSDANCE,:FIREPUNCH,:EXTREMESPEED,:FACADE],     :item => :FLAMEORB, :tier => 5},
     {:species => [:RAMPARDOS,:HYDREIGON],  :level => 8, :ability => :HUSTLE,  :nature => :ADAMANT,   :moves => [:DRAGONDANCE,:HEADSMASH,:OUTRAGE,:EARTHQUAKE],     :item => :FOCUSSASH, :tier => 5},
     {:species => [:TYRANITAR,:HITMONLEE],  :level => 7, :ability => :UNBURDEN,  :nature => :ADAMANT,   :moves => [:FAKEOUT,:CLOSECOMBAT,:ROCKSLIDE,:EARTHQUAKE],     :item => :NORMALGEM, :tier => 5},


### PR DESCRIPTION
Blissey/Goodra's nature was changed to Natural Cure in an earlier commit. Clearly a mistake since Natural Cure is an ability, not a nature.
https://github.com/infinitefusion/scripts/commit/a0a3f1706609eb69548383a9191bab4da051fb56#diff-1033a8bf5e28025ba626b1accd38606e28392a8edd66628e9f636f58274407a5L121

This pull request changes the pokémon's ability to Natural Cure and reverts its nature to Docile.

